### PR TITLE
Change macro name to `happy_path`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,12 +38,12 @@ following goals in mind:
 import Happy
 ```
 
-###### the `happy` macro
+###### the `happy_path` macro
 
-The `happy` macro takes a `do` block and rewrites any first-level pattern matching expression into a `case`.
+The `happy_path` macro takes a `do` block and rewrites any first-level pattern matching expression into a `case`.
 
 ```elixir
-happy do
+happy_path do
   {:ok, b} = a
   {:ok, d} = b
   c(d)
@@ -66,7 +66,7 @@ provide an `else` block with additional
 matching clauses:
 
 ```elixir
-happy do
+happy_path do
   {:ok, b} = a
   c(b)
 else
@@ -87,7 +87,7 @@ end
 ###### Example usage in a web application creating a user
 
 ```elixir
-happy do
+happy_path do
 
   %{valid?: true} = ch = User.changeset(params)
   {:ok, user} = Repo.insert(ch)

--- a/lib/happy.ex
+++ b/lib/happy.ex
@@ -7,10 +7,10 @@ defmodule Happy do
   # happy block with at least two expressions
   # using custom unhappy path
   @doc false
-  defmacro happy([do: block = {:__block__, _, xs = [a, b | c]},
+  defmacro happy_path([do: block = {:__block__, _, xs = [a, b | c]},
                   else: unhappy]) do
     if Enum.any?(xs, &pattern_match?/1) do
-      happy_path(a, b, c, unhappy)
+      happy(a, b, c, unhappy)
     else
       block
     end
@@ -19,44 +19,44 @@ defmodule Happy do
   # happy block with at least two expressions
   # using default unhappy path
   @doc false
-  defmacro happy([do: block = {:__block__, _, xs = [a, b | c]}]) do
+  defmacro happy_path([do: block = {:__block__, _, xs = [a, b | c]}]) do
     if Enum.any?(xs, &pattern_match?/1) do
-      happy_path(a, b, c, [])
+      happy(a, b, c, [])
     else
       block
     end
   end
 
   @doc false
-  defmacro happy([do: expr, else: _]), do: expr
+  defmacro happy_path([do: expr, else: _]), do: expr
   @doc false
-  defmacro happy([do: expr]), do: expr
+  defmacro happy_path([do: expr]), do: expr
 
   # append unhappy path to case when no more expressions remain
-  defp happy_path({:case, m = [happy: true], [e, [do: xs]]}, [], unhappy) do
+  defp happy({:case, m = [happy_path: true], [e, [do: xs]]}, [], unhappy) do
     {:case, m, [e, [do: xs ++ unhappy]]}
   end
 
-  defp happy_path(a, [], _u), do: a
-  defp happy_path(a, [b | xs], u), do: happy_path(a, b, xs, u)
+  defp happy(a, [], _u), do: a
+  defp happy(a, [b | xs], u), do: happy(a, b, xs, u)
 
   # create a case expression from a to b and continue with rest expressions
-  defp happy_path(a = {:=, _, _}, b, xs, u) do
+  defp happy(a = {:=, _, _}, b, xs, u) do
     {e, p} = pattern_match(a)
     quote do
       case(unquote(e)) do
         unquote(p) -> unquote(b)
       end
-    end |> happy_form |> happy_path(xs, u)
+    end |> happy_form |> happy(xs, u)
   end
 
   # create another nested case when another pattern matching found in chain
-  defp happy_path(a = {:case, [happy: true], _}, b = {:=, _, _}, xs, u) do
-    happy_path(a, [happy_path(b, xs, u)], u)
+  defp happy(a = {:case, [happy_path: true], _}, b = {:=, _, _}, xs, u) do
+    happy(a,  [happy(b, xs, u)], u)
   end
 
   # append `b` expression to current block case(p -> ax)
-  defp happy_path({:case, [happy: true],
+  defp happy({:case, [happy_path: true],
                     [e, [do: [{:->, _, [[p], {:__block__, _, ax}]}]]]},
       b, xs, u) do
     quote do
@@ -65,11 +65,11 @@ defmodule Happy do
           unquote_splicing(ax)
           unquote(b)
       end
-    end |> happy_form |> happy_path(xs, u)
+    end |> happy_form |> happy(xs, u)
   end
 
   # create a block by appending `b` expression to current case(p -> a)
-  defp happy_path({:case, [happy: true], [e, [do: [{:->, _, [[p], a]}]]]},
+  defp happy({:case, [happy_path: true], [e, [do: [{:->, _, [[p], a]}]]]},
       b, xs, u) do
     quote do
       case(unquote(e)) do
@@ -77,20 +77,20 @@ defmodule Happy do
            unquote(a)
            unquote(b)
       end
-    end |> happy_form |> happy_path(xs, u)
+    end |> happy_form |> happy(xs, u)
   end
 
   # create a block with `a` and `b` and continue with chain
-  defp happy_path(a, b, xs, u) do
+  defp happy(a, b, xs, u) do
     quote do
       unquote(a)
       unquote(b)
-    end |> happy_path(xs, u)
+    end |> happy(xs, u)
   end
 
   # mark a form with happy metadata
   defp happy_form({x, m, y}) do
-    {x, [happy: true] ++ m, y}
+    {x, [happy_path: true] ++ m, y}
   end
 
   # is the given form a pattern match?

--- a/test/happy_test.exs
+++ b/test/happy_test.exs
@@ -7,7 +7,7 @@ defmodule HappyTest do
 
   test "empty block expands to itself" do
     a = quote do
-      happy do
+      happy_path do
       end
     end
     b = quote do
@@ -17,7 +17,7 @@ defmodule HappyTest do
 
   test "single block expands to itself" do
     a = quote do
-      happy do
+      happy_path do
         foo
       end
     end
@@ -29,7 +29,7 @@ defmodule HappyTest do
 
   test "block without matches expands to itself" do
     a = quote do
-      happy do
+      happy_path do
         foo
         bar
       end
@@ -43,7 +43,7 @@ defmodule HappyTest do
 
   test "block with single match expands to itself" do
     a = quote do
-      happy do
+      happy_path do
         foo = bar
       end
     end
@@ -55,7 +55,7 @@ defmodule HappyTest do
 
   test "block with expr and match expands to itself" do
     a = quote do
-      happy do
+      happy_path do
         baz
         foo = baz
       end
@@ -70,7 +70,7 @@ defmodule HappyTest do
 
   test "block with elixir cond expands to itself" do
     a = quote do
-      happy do
+      happy_path do
         cond do
           true -> nil
         end
@@ -88,7 +88,7 @@ defmodule HappyTest do
 
   test "block with match and expr expands to case" do
     a = quote do
-      happy do
+      happy_path do
         foo = bar
         foo + 1
       end
@@ -103,7 +103,7 @@ defmodule HappyTest do
 
   test "block with match and two exprs expands to case" do
     a = quote do
-      happy do
+      happy_path do
         foo = bar
         baz
         bat
@@ -121,7 +121,7 @@ defmodule HappyTest do
 
   test "block with match and three exprs expands to case" do
     a = quote do
-      happy do
+      happy_path do
         foo = bar
         baz
         bat
@@ -141,7 +141,7 @@ defmodule HappyTest do
 
   test "block with match exprs and other match expands to nested case" do
     a = quote do
-      happy do
+      happy_path do
         foo = bar
         baz
         bat = man
@@ -162,7 +162,7 @@ defmodule HappyTest do
 
   test "single block with else expands to itself" do
     a = quote do
-      happy do
+      happy_path do
         foo
       else
         :true -> :unhappy
@@ -176,7 +176,7 @@ defmodule HappyTest do
 
   test "happy with else block, match and expr expands to case" do
     a = quote do
-      happy do
+      happy_path do
         foo = bar
         foo + 1
       else
@@ -194,7 +194,7 @@ defmodule HappyTest do
 
   test "happy block with multiple pattern matching" do
     a = quote do
-      happy do
+      happy_path do
         c = b = a
         e
       end


### PR DESCRIPTION
I think a name like `happy_path` could make more explicit a block like

``` elixir
happy_path do
  code
else
  code
end
```

The part above the `else` is the one and only happy_path.
